### PR TITLE
Feat: add support for a custom route prefix

### DIFF
--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -13,6 +13,7 @@ class Route {
    * @param {String} info.sourceAccount
    * @param {String} info.destinationAccount
    * @param {Object} info.additionalInfo
+   * @param {String} info.targetPrefix
    */
   constructor (curve, hops, info) {
     this.curve = curve instanceof LiquidityCurve ? curve : new LiquidityCurve(curve)
@@ -20,6 +21,11 @@ class Route {
     this.sourceLedger = hops[0]
     this.nextLedger = hops[1]
     this.destinationLedger = hops[hops.length - 1]
+
+    // if targetPrefix is specified, then destinations matching 'targetPrefix'
+    // will follow this route, rather than destinations matching
+    // 'destinationLedger'
+    this.targetPrefix = info.targetPrefix || this.destinationLedger
 
     this.minMessageWindow = info.minMessageWindow
     this.expiresAt = info.expiresAt
@@ -67,7 +73,8 @@ class Route {
       minMessageWindow: this.minMessageWindow + tailRoute.minMessageWindow,
       isLocal: this.isLocal && tailRoute.isLocal,
       sourceAccount: this.sourceAccount,
-      expiresAt: Date.now() + expiryDuration
+      expiresAt: Date.now() + expiryDuration,
+      targetPrefix: tailRoute.targetPrefix
     })
   }
 
@@ -87,7 +94,8 @@ class Route {
     return new Route(this.curve.simplify(maxPoints), this._simpleHops(), {
       minMessageWindow: this.minMessageWindow,
       additionalInfo: this.additionalInfo,
-      isLocal: this.isLocal
+      isLocal: this.isLocal,
+      targetPrefix: this.targetPrefix
     })
   }
 
@@ -132,7 +140,8 @@ function dataToRoute (data) {
     isLocal: false,
     sourceAccount: data.source_account,
     destinationAccount: data.destination_account,
-    additionalInfo: data.additional_info
+    additionalInfo: data.additional_info,
+    targetPrefix: data.target_prefix
   })
 }
 

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -66,13 +66,13 @@ class RoutingTables {
     this.eachSource((tableFromA, ledgerA) => {
       added = this._addRouteFromSource(tableFromA, ledgerA, route) || added
     })
-    if (added) debug('add route', route.sourceAccount, route.destinationLedger)
+    if (added) debug('add route matching', route.targetPrefix, ':', route.sourceAccount, route.destinationLedger)
     return added
   }
 
   _addRouteFromSource (tableFromA, ledgerA, routeFromBToC) {
     const ledgerB = routeFromBToC.sourceLedger
-    const ledgerC = routeFromBToC.destinationLedger
+    const ledgerC = routeFromBToC.targetPrefix
     const connectorFromBToC = routeFromBToC.sourceAccount
     let added = false
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -38,6 +38,8 @@ describe('Route', function () {
       assert.equal(route.sourceLedger, ledgerA)
       assert.equal(route.nextLedger, ledgerB)
       assert.equal(route.destinationLedger, ledgerC)
+      assert.equal(route.targetPrefix, route.destinationLedger,
+        'should default target prefix to destination ledger')
 
       assert.equal(route.minMessageWindow, 3)
       assert.equal(route.expiresAt, 1234)

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -120,6 +120,24 @@ describe('RoutingTables', function () {
         undefined)
     })
 
+    it('creates a route with a custom prefix, if supplied', function () {
+      const route = {
+        target_prefix: 'prefix.',
+        source_ledger: ledgerB,
+        destination_ledger: ledgerC,
+        source_account: ledgerC + 'mary',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }
+
+      // will be stored in destinations under 'prefix.'
+      assert.equal(this.tables.addRoute(route), true)
+
+      assertSubset(
+        this.tables.sources.get(ledgerA).destinations.get('prefix.').get(ledgerC + 'mary'),
+        { destinationLedger: ledgerC, targetPrefix: 'prefix.' })
+    })
+
     it('doesn\'t override local pair paths with a remote one', function () {
       assert.equal(this.tables.addRoute({
         source_ledger: ledgerA,


### PR DESCRIPTION
adds an extra argument to `addRoute` allowing a custom destination prefix to be specified. Depended on by https://github.com/interledgerjs/ilp-connector/pull/238