### PR TITLE
feat: add destination{Precision,Scale}

### DIFF
--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const debug = require('debug')('ilp-routing:routing-tables')
+const isUndefined = require('lodash/fp/isUndefined')
+const omitUndefined = require('lodash/fp/omitBy')(isUndefined)
 
 const PrefixMap = require('./prefix-map')
 const Route = require('./route')
@@ -178,7 +180,7 @@ class RoutingTables {
     const nextLedger = nextHop.bestRoute.nextLedger
     const routeFromAToB = this._getLocalPairRoute(sourceLedger, nextLedger)
     const isFinal = nextLedger === finalLedger
-    return {
+    return omitUndefined({
       isFinal: isFinal,
       isLocal: nextHop.bestRoute.isLocal,
       sourceLedger: sourceLedger,
@@ -188,9 +190,11 @@ class RoutingTables {
       destinationCreditAccount: isFinal ? null : nextHop.bestHop,
       finalLedger: finalLedger,
       finalAmount: finalAmount,
+      finalPrecision: nextHop.bestRoute.destinationPrecision,
+      finalScale: nextHop.bestRoute.destinationScale,
       minMessageWindow: nextHop.bestRoute.minMessageWindow,
       additionalInfo: isFinal ? nextHop.bestRoute.additionalInfo : undefined
-    }
+    })
   }
 
   /**
@@ -207,7 +211,7 @@ class RoutingTables {
     const nextLedger = nextHop.bestRoute.nextLedger
     const routeFromAToB = this._getLocalPairRoute(sourceLedger, nextLedger)
     const isFinal = nextLedger === finalLedger
-    return {
+    return omitUndefined({
       isFinal: isFinal,
       isLocal: nextHop.bestRoute.isLocal,
       sourceLedger: sourceLedger,
@@ -217,9 +221,11 @@ class RoutingTables {
       destinationCreditAccount: isFinal ? null : nextHop.bestHop,
       finalLedger: finalLedger,
       finalAmount: nextHop.bestValue.toString(),
+      finalPrecision: nextHop.bestRoute.destinationPrecision,
+      finalScale: nextHop.bestRoute.destinationScale,
       minMessageWindow: nextHop.bestRoute.minMessageWindow,
       additionalInfo: isFinal ? nextHop.bestRoute.additionalInfo : undefined
-    }
+    })
   }
 
   _findBestHopForSourceAmount (source, destination, amount) {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -30,7 +30,9 @@ describe('Route', function () {
         isLocal: true,
         sourceAccount: markA,
         destinationAccount: markC,
-        additionalInfo: {foo: 'bar'}
+        additionalInfo: {foo: 'bar'},
+        destinationPrecision: 10,
+        destinationScale: 2
       })
 
       assert.ok(route.curve instanceof LiquidityCurve)
@@ -46,7 +48,36 @@ describe('Route', function () {
       assert.equal(route.isLocal, true)
       assert.equal(route.sourceAccount, markA)
       assert.equal(route.destinationAccount, markC)
+      assert.equal(route.destinationPrecision, 10)
+      assert.equal(route.destinationScale, 2)
       assert.deepStrictEqual(route.additionalInfo, {foo: 'bar'})
+    })
+
+    it('succeeds if missing both destination{Precision,Scale}', function () {
+      const route = new Route([[0, 0], [100, 200]], hopsABC, {
+        sourceAccount: markA,
+        destinationAccount: markC
+      })
+      assert.equal(route.destinationPrecision, undefined)
+      assert.equal(route.destinationScale, undefined)
+    })
+
+    it('fails if only precision is missing', function () {
+      assert.throws(() =>
+        new Route([[0, 0], [100, 200]], hopsABC, {
+          sourceAccount: markA,
+          destinationAccount: markC,
+          destinationScale: 2
+        }), /Missing destinationPrecision or destinationScale/)
+    })
+
+    it('fails if only scale is missing', function () {
+      assert.throws(() =>
+        new Route([[0, 0], [100, 200]], hopsABC, {
+          sourceAccount: markA,
+          destinationAccount: markC,
+          destinationPrecision: 10
+        }), /Missing destinationPrecision or destinationScale/)
     })
   })
 
@@ -102,7 +133,9 @@ describe('Route', function () {
       })
       const route2 = new Route([ [0, 0], [50, 60] ], hopsBCD, {
         isLocal: false,
-        minMessageWindow: 2
+        minMessageWindow: 2,
+        destinationPrecision: 10,
+        destinationScale: 2
       })
       const joinedRoute = route1.join(route2, 1000)
 
@@ -117,6 +150,9 @@ describe('Route', function () {
       assert.equal(joinedRoute.minMessageWindow, 3)
       // It sets an expiry in the future
       assert.ok(Date.now() < joinedRoute.expiresAt)
+      // It uses the tail route's precision/scale.
+      assert.equal(joinedRoute.destinationPrecision, 10)
+      assert.equal(joinedRoute.destinationScale, 2)
     })
 
     it('sets isLocal to true if both routes are local', function () {

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -341,7 +341,9 @@ describe('RoutingTables', function () {
         destination_ledger: ledgerC,
         source_account: ledgerB + 'martin',
         min_message_window: 2, // this min_message_window is higher, so it is used
-        points: [ [0, 0], [100, 100] ]
+        points: [ [0, 0], [100, 100] ],
+        destination_precision: 10,
+        destination_scale: 2
       })
 
       assert.deepStrictEqual(this.tables.toJSON(10), [
@@ -361,14 +363,17 @@ describe('RoutingTables', function () {
             [100, 60], /* .. mary (max) .. */
             [120, 60], /* .. mark .. */
             [200, 100] /* .. mark (max) */
-          ]
+          ],
+          destination_precision: 10,
+          destination_scale: 2
         }, {
           source_ledger: ledgerA,
           destination_ledger: ledgerB,
           min_message_window: 1,
           source_account: markA,
           points: [ [0, 0], [200, 100] ]
-        }])
+        }
+      ])
     })
 
     ;[
@@ -456,8 +461,7 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + 'mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2,
-          additionalInfo: undefined
+          minMessageWindow: 2
         })
     })
 
@@ -499,8 +503,7 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + 'mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2,
-          additionalInfo: undefined
+          minMessageWindow: 2
         })
     })
   })


### PR DESCRIPTION
Store `destination{Precision,Scale}` in the routes so that it is relayed to adjacent connectors.

Requires https://github.com/interledgerjs/five-bells-shared/pull/174

Related to https://github.com/interledgerjs/ilp-connector/issues/270