### PR TITLE
feat: include "curve" on hops; various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ Given a destination amount, look up the corresponding source amount.
 
 #### `route.combine(alternateRoute) ⇒ Route`
 
-Combine two parallel routes.
+Combine two parallel routes, generating a new curve consisting of the best segments of each.
 
 #### `route.join(tailRoute) ⇒ Route`
 
-Join two routes end-to-end.
+Compose two routes end-to-end: `A→B.join(B→C)` becomes `A→C`.
+
+#### `route.shiftX(dx) ⇒ Route`
+
+Shift a route's curve left or right.
 
 #### `route.shiftY(dy) ⇒ Route`
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
+const LiquidityCurve = require('./src/lib/liquidity-curve')
 const Route = require('./src/lib/route')
 const RoutingTables = require('./src/lib/routing-tables')
 
 module.exports = {
+  LiquidityCurve,
   Route,
   RoutingTables
 }

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -49,7 +49,7 @@ class Route {
   }
 
   // Proxy some functions to the LiquidityCurve.
-  amountAt (x) { return Math.max(0, this.curve.amountAt(x)) }
+  amountAt (x) { return this.curve.amountAt(x) }
   amountReverse (y) { return this.curve.amountReverse(y) }
   getPoints () { return this.curve.getPoints() }
 
@@ -93,6 +93,14 @@ class Route {
       destinationPrecision: tailRoute.destinationPrecision,
       destinationScale: tailRoute.destinationScale
     })
+  }
+
+  /**
+   * @param {Number} dx
+   * @returns {Route}
+   */
+  shiftX (dx) {
+    return new Route(this.curve.shiftX(dx), this.hops, this)
   }
 
   /**

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -193,6 +193,7 @@ class RoutingTables {
       finalPrecision: nextHop.bestRoute.destinationPrecision,
       finalScale: nextHop.bestRoute.destinationScale,
       minMessageWindow: nextHop.bestRoute.minMessageWindow,
+      liquidityCurve: nextHop.bestRoute.curve.getPoints(),
       additionalInfo: isFinal ? nextHop.bestRoute.additionalInfo : undefined
     })
   }
@@ -224,6 +225,7 @@ class RoutingTables {
       finalPrecision: nextHop.bestRoute.destinationPrecision,
       finalScale: nextHop.bestRoute.destinationScale,
       minMessageWindow: nextHop.bestRoute.minMessageWindow,
+      liquidityCurve: nextHop.bestRoute.curve.getPoints(),
       additionalInfo: isFinal ? nextHop.bestRoute.additionalInfo : undefined
     })
   }

--- a/test/liquidity-curve.test.js
+++ b/test/liquidity-curve.test.js
@@ -27,6 +27,13 @@ describe('LiquidityCurve', function () {
       }, /InvalidLiquidityCurveError: Curve has point with negative x-coordinate/)
     })
 
+    it('throws InvalidLiquidityCurveError if a point has a negative y-coordinate', function () {
+      const curve = new LiquidityCurve([])
+      assert.throws(() => {
+        curve.setPoints([ [1, -5], [2, 5] ])
+      }, /InvalidLiquidityCurveError: Curve has point with negative y-coordinate/)
+    })
+
     it('throws InvalidLiquidityCurveError if the x-coordinates are not strictly increasing', function () {
       const curve = new LiquidityCurve([])
       assert.throws(() => {
@@ -73,10 +80,6 @@ describe('LiquidityCurve', function () {
     it('returns an exact "y" value when possible', function () {
       const curve = new LiquidityCurve([[0, 0], [50, 100], [100, 1000]])
       assert.equal(curve.amountAt(50), 100)
-    })
-
-    it('returns negative values', function () {
-      assert.equal(curve.shiftY(-40).amountAt(10), -20)
     })
   })
 
@@ -138,7 +141,7 @@ describe('LiquidityCurve', function () {
       const joinedCurve = curve1.join(curve2)
 
       assert.deepStrictEqual(joinedCurve.points,
-        [ [0, 0], [100, 60], [200, 60] ])
+        [ [0, 0], [100, 60] ])
       assert.equal(joinedCurve.amountAt(50), 30)
       assert.equal(joinedCurve.amountAt(100), 60)
       assert.equal(joinedCurve.amountAt(200), 60)
@@ -152,12 +155,32 @@ describe('LiquidityCurve', function () {
         [ [0, 0], [50, 150] ])
     })
 
-    it('handles negative y-coordinates', function () {
-      const curve1 = new LiquidityCurve([ [0, -1], [10, 1] ])
-      const curve2 = new LiquidityCurve([ [0, -1], [1, 2] ])
+    it('handles joining with a right-shifted curve', function () {
+      const curve1 = new LiquidityCurve([ [0, 0], [10, 10] ])
+      const curve2 = new LiquidityCurve([ [1, 1], [11, 11] ])
       const joinedCurve = curve1.join(curve2)
       assert.deepEqual(joinedCurve.points,
-        [ [0, -1], [5, -1], [10, 2] ])
+        [ [1, 1], [10, 10] ])
+    })
+  })
+
+  describe('shiftX', function () {
+    it('shifts all of the points\' Xs by the specified amount', function () {
+      const curve = new LiquidityCurve([ [0, 0], [50, 60], [100, 100] ])
+      assert.deepStrictEqual(curve.shiftX(1).points,
+        [ [1, 0], [51, 60], [101, 100] ])
+    })
+
+    it('stays positive', function () {
+      const curve = new LiquidityCurve([ [0, 0], [10, 10] ])
+      assert.deepStrictEqual(curve.shiftX(-5).points,
+        [ [0, 5], [5, 10] ])
+    })
+
+    it('shifts a single point and stays positive', function () {
+      const curve = new LiquidityCurve([ [5, 5] ])
+      assert.deepStrictEqual(curve.shiftX(-10).points,
+        [ [0, 5] ])
     })
   })
 
@@ -166,6 +189,12 @@ describe('LiquidityCurve', function () {
       const curve = new LiquidityCurve([ [0, 0], [50, 60], [100, 100] ])
       assert.deepStrictEqual(curve.shiftY(1).points,
         [ [0, 1], [50, 61], [100, 101] ])
+    })
+
+    it('stays positive', function () {
+      const curve = new LiquidityCurve([ [0, 0], [10, 10] ])
+      assert.deepStrictEqual(curve.shiftY(-5).points,
+        [ [5, 0], [10, 5] ])
     })
   })
 })

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -141,7 +141,7 @@ describe('Route', function () {
 
       // It joins the curves
       assert.deepEqual(joinedRoute.getPoints(),
-        [ [0, 0], [100, 60], [200, 60] ])
+        [ [0, 0], [100, 60] ])
       // It concatenates the hops
       assert.deepEqual(joinedRoute.hops, [ledgerA, ledgerB, ledgerC, ledgerD])
       // It isn't a local pair.

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -461,7 +461,8 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + 'mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2
+          minMessageWindow: 2,
+          liquidityCurve: [ [0, 0], [200, 50] ]
         })
     })
 
@@ -479,7 +480,8 @@ describe('RoutingTables', function () {
           finalLedger: ledgerB,
           finalAmount: '50',
           minMessageWindow: 1,
-          additionalInfo: {rate_info: '0.5'}
+          additionalInfo: {rate_info: '0.5'},
+          liquidityCurve: [ [0, 0], [200, 100] ]
         })
     })
 
@@ -503,7 +505,8 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + 'mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2
+          minMessageWindow: 2,
+          liquidityCurve: [ [0, 0], [200, 50] ]
         })
     })
   })
@@ -523,7 +526,8 @@ describe('RoutingTables', function () {
           finalLedger: ledgerB,
           finalAmount: '50',
           minMessageWindow: 1,
-          additionalInfo: {rate_info: '0.5'}
+          additionalInfo: {rate_info: '0.5'},
+          liquidityCurve: [ [0, 0], [200, 100] ]
         })
     })
   })


### PR DESCRIPTION
* Export `LiquidityCurve`.
* Disallow negative y values.
* Document `join()` and `combine()` (fixes https://github.com/interledgerjs/ilp-routing/issues/23).
* Fix `join()`: don't include extra points (extra `[0,0]`s can cause problems, see test `"handles joining with a right-shifted curve"`).
* Add `{LiquidityCurve,Route}#shiftX()`.
* Fix `shiftY()`: ensure that the resulting curve is never negative.
* Return `curve` on `findBestHopFor{Destination,Source}Amount()`.