### PR TITLE
Feat/mw improved route broadcast

### DIFF
--- a/src/lib/liquidity-curve.js
+++ b/src/lib/liquidity-curve.js
@@ -12,13 +12,13 @@ class LiquidityCurve {
     this.points = points.slice()
     for (let i = 0; i < this.points.length; i++) {
       let point = this.points[i]
-      if (point[0] < 0) throw new InvalidLiquidityCurveError('Curve has point with negative x-coordinate')
-      if (point[1] < 0) throw new InvalidLiquidityCurveError('Curve has point with negative y-coordinate')
+      if (point[0] < 0) throw new InvalidLiquidityCurveError('Curve has point with negative x-coordinate', this.points)
+      if (point[1] < 0) throw new InvalidLiquidityCurveError('Curve has point with negative y-coordinate', this.points)
       if (prev && point[0] <= prev[0]) {
-        throw new InvalidLiquidityCurveError('Curve x-coordinates must strictly increase in series')
+        throw new InvalidLiquidityCurveError('Curve x-coordinates must strictly increase in series', this.points)
       }
       if (prev && point[1] < prev[1]) {
-        throw new InvalidLiquidityCurveError('Curve y-coordinates must increase in series')
+        throw new InvalidLiquidityCurveError('Curve y-coordinates must increase in series', this.points)
       }
       prev = point
     }
@@ -244,7 +244,8 @@ function intersectLineSegments (line0, line1) {
 }
 
 class InvalidLiquidityCurveError extends Error {
-  constructor (message) {
+  constructor (message, points) {
+    message = message + ' points:' + JSON.stringify(points)
     super(message)
     this.name = 'InvalidLiquidityCurveError'
   }

--- a/src/lib/prefix-map.js
+++ b/src/lib/prefix-map.js
@@ -22,6 +22,7 @@ class PrefixMap {
   }
 
   keys () { return this.prefixes }
+
   size () { return this.prefixes.length }
 
   resolve (key) {

--- a/src/lib/routing-table.js
+++ b/src/lib/routing-table.js
@@ -21,11 +21,18 @@ class RoutingTable {
     routes.set(nextHop, route)
   }
 
+  /**
+   * @returns {Boolean} True if connectivity has been lost
+   */
   removeRoute (destination, nextHop) {
     const routes = this.destinations.get(destination)
-    if (!routes) return
+    if (!routes) return false
     routes.delete(nextHop)
-    if (routes.size === 0) this.destinations.delete(destination)
+    if (routes.size === 0) {
+      this.destinations.delete(destination)
+      return true
+    }
+    return false
   }
 
   findBestHopForSourceAmount (destination, sourceAmount) {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -205,4 +205,21 @@ describe('Route', function () {
       assert.strictEqual(route2.isExpired(), true)
     })
   })
+
+  describe('bumpExpiration', function () {
+    it('doesn\'t expire routes that have been bumped, but they expire when specified', function () {
+      const route1 = new Route([ [0, 0], [200, 100] ], [ledgerA, ledgerB], {})
+      const route2 = new Route([ [0, 0], [200, 100] ], [ledgerA, ledgerB], {expiresAt: Date.now() + 1000})
+      assert.strictEqual(route1.isExpired(), false)
+      assert.strictEqual(route2.isExpired(), false)
+
+      route2.bumpExpiration(3000)
+      this.clock.tick(2000)
+      assert.strictEqual(route1.isExpired(), false)
+      assert.strictEqual(route2.isExpired(), false)
+      this.clock.tick(5000)
+      assert.strictEqual(route1.isExpired(), false)
+      assert.strictEqual(route2.isExpired(), true)
+    })
+  })
 })


### PR DESCRIPTION
These changes are necessary for the same branch in ilp-connector.

The primary features this adds are:
* a per-route version ('epoch'), used to prevent redundant rebroadcast
* expiry extension ('bumpConnector')
* invalidation of routes by connector
* lost-ledger-connectivity is returned when routes are removed
