### PR TITLE
Fix/mw route versioning

### DIFF
--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -59,9 +59,8 @@ class Route {
     return new Route(combinedCurve, combinedHops, {
       minMessageWindow: Math.max(this.minMessageWindow, alternateRoute.minMessageWindow),
       isLocal: false,
-      // todo? should this be min? not sure of the full semantics of this at the moment
-      addedDuringEpoch: Math.max(alternateRoute.addedDuringEpoch, this.addedDuringEpoch)
 
+      addedDuringEpoch: Math.max(alternateRoute.addedDuringEpoch, this.addedDuringEpoch)
     })
   }
 
@@ -109,13 +108,13 @@ class Route {
    * @param {Integer} maxPoints
    * @returns {Route}
    */
-  simplify (maxPoints, addedDuringEpoch) {
+  simplify (maxPoints) {
     return new Route(this.curve.simplify(maxPoints), this._simpleHops(), {
       minMessageWindow: this.minMessageWindow,
       additionalInfo: this.additionalInfo,
       isLocal: this.isLocal,
       targetPrefix: this.targetPrefix,
-      addedDuringEpoch: addedDuringEpoch
+      addedDuringEpoch: this.addedDuringEpoch
     })
   }
 

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -443,7 +443,7 @@ describe('RoutingTables', function () {
             [120, 60], /* .. mark .. */
             [200, 100] /* .. mark (max) */
           ],
-          added_during_epoch: 0
+          added_during_epoch: 2
         }, {
           source_ledger: ledgerA,
           destination_ledger: ledgerB,
@@ -502,7 +502,7 @@ describe('RoutingTables', function () {
           min_message_window: 2,
           source_account: markA,
           points: test.output,
-          added_during_epoch: 0
+          added_during_epoch: 2
         })
       })
     }, this)


### PR DESCRIPTION
Combined with the removal of broadcast epoch incrementing from ilp-connector's route-broadcaster, fixes the route version logic so that routes aren't rebroadcast redundantly.

On its own, this change doesn't make anything more broken, so I suggest merging it first, with a patch version bump.