### PR TITLE
fix: don't add expiry when joining two non-expiring routes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.6.0
+    version: 7.7.1
 test:
   override:
     # Run lint

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -82,7 +82,7 @@ class Route {
       minMessageWindow: this.minMessageWindow + tailRoute.minMessageWindow,
       isLocal: this.isLocal && tailRoute.isLocal,
       sourceAccount: this.sourceAccount,
-      expiresAt: Date.now() + expiryDuration,
+      expiresAt: expiryDuration && Date.now() + expiryDuration,
       targetPrefix: tailRoute.targetPrefix,
       addedDuringEpoch: addedDuringEpoch
     })

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -69,11 +69,11 @@ class RoutingTables {
    * @param {Route|RouteData} _route from ledger B→C
    * @returns {Boolean} whether or not a new route was added
    */
-  addRoute (_route) {
+  addRoute (_route, noExpire) {
     const route = Route.fromData(_route, this.currentEpoch)
     let added = false
     this.eachSource((tableFromA, ledgerA) => {
-      added = this._addRouteFromSource(tableFromA, ledgerA, route) || added
+      added = this._addRouteFromSource(tableFromA, ledgerA, route, noExpire) || added
     })
     if (added) {
       debug('added route matching ', route.targetPrefix, ':', route.sourceAccount, route.destinationLedger, 'epoch:', route.addedDuringEpoch)
@@ -83,7 +83,7 @@ class RoutingTables {
     return added
   }
 
-  _addRouteFromSource (tableFromA, ledgerA, routeFromBToC) {
+  _addRouteFromSource (tableFromA, ledgerA, routeFromBToC, noExpire) {
     const ledgerB = routeFromBToC.sourceLedger
     const ledgerC = routeFromBToC.targetPrefix
     const connectorFromBToC = routeFromBToC.sourceAccount
@@ -100,7 +100,8 @@ class RoutingTables {
     }
 
     // Make sure the routes can be joined.
-    const routeFromAToC = routeFromAToB.join(routeFromBToC, this.expiryDuration, this.currentEpoch)
+    const expiryDuration = noExpire ? null : this.expiryDuration
+    const routeFromAToC = routeFromAToB.join(routeFromBToC, expiryDuration, this.currentEpoch)
     if (!routeFromAToC) {
       return
     }

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -276,6 +276,26 @@ describe('RoutingTables', function () {
       assert.deepStrictEqual(lll, [ledgerC])
       assert.equal(this.tables.toJSON(10).length, 2)
     })
+
+    it('doesn\'t expire noExpire routes', function () {
+      this.tables.addRoute({
+        source_ledger: ledgerB,
+        destination_ledger: ledgerC,
+        source_account: ledgerB + 'mary',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }, true) // noExpire
+
+      // expire nothing
+      assert.equal(this.tables.toJSON(10).length, 3)
+      this.tables.removeExpiredRoutes()
+      assert.equal(this.tables.toJSON(10).length, 3)
+
+      this.clock.tick(45001)
+      this.tables.removeExpiredRoutes()
+      // it shouldn't have expired
+      assert.equal(this.tables.toJSON(10).length, 3)
+    })
   })
 
   describe('bumpConnector', function () {


### PR DESCRIPTION
Fix is based on an old version so we can backport it.

Some routes that should be fixed in the routing table were getting expired after being joined. Now the joined routes won't expire unless one of the routes being joined expires. I also added a log statement to make this kind of thing easier to catch.

Additionally, the `Route.fromData` function wasn't including an expires_at, so that functionality wasn't actually being tested. The expiresAt field was added there, so now the tests pass on this branch.