### PR TITLE
fix: don't announce loopback routes

### DIFF
--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -64,7 +64,7 @@ class RoutingTables {
 
   /**
    * Given a `route` B→C, create a route A→C for each source ledger A with a
-   * local route to B.
+   * local route to B, unless A == B.
    *
    * @param {Route|RouteData} _route from ledger B→C
    * @returns {Boolean} whether or not a new route was added
@@ -73,6 +73,9 @@ class RoutingTables {
     const route = Route.fromData(_route, this.currentEpoch)
     let added = false
     this.eachSource((tableFromA, ledgerA) => {
+      if (ledgerA === _route.sourceLedger) { // don't add loopback routes
+        return
+      }
       added = this._addRouteFromSource(tableFromA, ledgerA, route, noExpire) || added
     })
     if (added) {


### PR DESCRIPTION
@sentientwaffle as discussed on slack, suppose you and I are peered, using ledger `peer.dj-mich.`, and I send you a route which is `peer.dj-mich. -> g.mich.`. That’s useful to you, so you store it in your routing table. But then when you broadcast routes to me, you should exclude that route, since if *i* want to route to `g.mich.`, I wouldn’t go through you.

So basically, “don’t echo routes back to the peer where they came from”