### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "code42day-vis-why": "^1.0.3",
+    "vis-why": "^1.2.2",
     "debug": "^2.2.0",
     "lodash": "^4.14.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,16 +12,18 @@
     "lodash": "^4.14.1"
   },
   "devDependencies": {
-    "cz-conventional-changelog": "^1.1.6",
-    "eslint": "^2.6.0",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.2",
+    "cz-conventional-changelog": "^2.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1",
     "five-bells-integration-test-loader": "^1.0.1",
-    "ghooks": "^1.2.1",
+    "ghooks": "^2.0.0",
     "istanbul": "^0.4.5",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.4",
+    "mocha": "^3.3.0",
+    "sinon": "^2.2.0",
     "validate-commit-msg": "^2.6.1"
   },
   "scripts": {

--- a/src/lib/liquidity-curve.js
+++ b/src/lib/liquidity-curve.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const simplify = require('code42day-vis-why')
+const simplify = require('vis-why')
 
 const MAX_ROUNDING_FACTOR = 1.000001
 


### PR DESCRIPTION
This PR is mostly to remove a deprecation warning when installing ILP kit. Also updates lint rules, but looks like our code is already compliant with the stricter rules. Neat.