### PR TITLE
feat: BREAKING integer points

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@
 
 #### `new Route(curve, hops, info)`
 #### `Route.fromData(routeData) ⇒ Route`
-#### `route.amountAt(x) ⇒ Number`
-
-Given a source amount, look up the corresponding destination amount.
-
-#### `route.amountReverse(y) ⇒ Number`
-
-Given a destination amount, look up the corresponding source amount.
-
 #### `route.getPoints(y) ⇒ Point[]`
 
 #### `route.combine(alternateRoute) ⇒ Route`

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 'use strict'
 
+const PrefixMap = require('./src/lib/prefix-map')
 const LiquidityCurve = require('./src/lib/liquidity-curve')
 const Route = require('./src/lib/route')
 const RoutingTables = require('./src/lib/routing-tables')
 
 module.exports = {
+  PrefixMap,
   LiquidityCurve,
   Route,
   RoutingTables

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "test": "test"
   },
   "dependencies": {
+    "bignumber.js": "^4.0.1",
     "vis-why": "^1.2.2",
     "debug": "^2.2.0",
     "lodash": "^4.14.1",
-    "long": "^3.2.0",
-    "oer-utils": "^1.3.2"
+    "long": "^3.2.0"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
     "vis-why": "^1.2.2",
     "debug": "^2.2.0",
-    "lodash": "^4.14.1"
+    "lodash": "^4.14.1",
+    "long": "^3.2.0",
+    "oer-utils": "^1.3.2"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.0.0",

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -6,7 +6,7 @@ const LiquidityCurve = require('./liquidity-curve')
 
 class Route {
   /**
-   * @param {LiquidityCurve|Point[]} curve
+   * @param {LiquidityCurve|Point[]|Buffer} curve
    * @param {Object} info
    * @param {String} info.sourceLedger - the ledger through which an incoming route enters this connector
    * @param {String} info.nextLedger - the ledger to which this connector should forward payments
@@ -115,7 +115,7 @@ class Route {
     // If N1 === J, don't include J in the joined paths
     // If N2 === D2, don't include N2 in the joined paths
     const havePaths = {}
-    this.paths.map(headPath => {
+    this.paths.map((headPath) => {
       if (this.destinationLedger !== this.nextLedger) {
         // N1 !== J, so include J:
         headPath = headPath.concat(this.destinationLedger)
@@ -124,7 +124,7 @@ class Route {
         // N2 !== D2, so include N2:
         headPath = headPath.concat(tailRoute.nextLedger)
       }
-      tailRoute.paths.map(tailPath => {
+      tailRoute.paths.map((tailPath) => {
         havePaths[ JSON.stringify(headPath.concat(tailPath)) ] = true
       })
     })
@@ -197,7 +197,7 @@ class Route {
     return omitUndefined({
       source_ledger: this.sourceLedger,
       destination_ledger: this.destinationLedger,
-      points: this.getPoints(),
+      points: this.curve.toBuffer().toString('base64'),
       min_message_window: this.minMessageWindow,
       source_account: this.sourceAccount,
       added_during_epoch: this.addedDuringEpoch,
@@ -233,6 +233,7 @@ function dataToRoute (data, currentEpoch) {
     sourceLedger: data.source_ledger,
     nextLedger: data.destination_ledger,
     minMessageWindow: data.min_message_window,
+    expiresAt: data.expires_at,
     isLocal: false,
     sourceAccount: data.source_account,
     destinationAccount: data.destination_account,

--- a/src/lib/routing-table.js
+++ b/src/lib/routing-table.js
@@ -44,13 +44,13 @@ class RoutingTable {
     }
 
     let bestHop = null
-    let bestValue = -1
+    let bestValue = null
     let bestRoute = null
     routes.forEach((route, nextHop) => {
       const value = route.amountAt(sourceAmount)
-      if (value > bestValue) {
+      if (!bestValue || value.gt(bestValue)) {
         bestHop = nextHop
-        bestValue = value
+        bestValue = value.toString()
         bestRoute = route
       }
     })
@@ -77,9 +77,9 @@ class RoutingTable {
     let bestRoute = null
     routes.forEach((route, nextHop) => {
       const cost = route.amountReverse(destinationAmount)
-      if (cost < bestCost) {
+      if (cost.lt(bestCost)) {
         bestHop = nextHop
-        bestCost = cost
+        bestCost = cost.toString()
         bestRoute = route
       }
     })

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -258,14 +258,13 @@ class RoutingTables {
       isFinal: isFinal,
       isLocal: nextHop.bestRoute.isLocal,
       sourceLedger: sourceLedger,
-      sourceAmount: nextHop.bestCost.toString(),
+      sourceAmount: nextHop.bestCost,
       destinationLedger: nextLedger,
       destinationAmount: routeFromAToB.amountAt(nextHop.bestCost).toString(),
       destinationCreditAccount: isFinal ? null : nextHop.bestHop,
       finalLedger: finalLedger,
       finalAmount: finalAmount,
       minMessageWindow: nextHop.bestRoute.minMessageWindow,
-      liquidityCurve: nextHop.bestRoute.curve.getPoints(),
       additionalInfo: isFinal ? nextHop.bestRoute.additionalInfo : undefined
     })
   }
@@ -293,9 +292,8 @@ class RoutingTables {
       destinationAmount: routeFromAToB.amountAt(+sourceAmount).toString(),
       destinationCreditAccount: isFinal ? null : nextHop.bestHop,
       finalLedger: finalLedger,
-      finalAmount: nextHop.bestValue.toString(),
+      finalAmount: nextHop.bestValue,
       minMessageWindow: nextHop.bestRoute.minMessageWindow,
-      liquidityCurve: nextHop.bestRoute.curve.getPoints(),
       additionalInfo: isFinal ? nextHop.bestRoute.additionalInfo : undefined
     })
   }

--- a/test/liquidity-curve.test.js
+++ b/test/liquidity-curve.test.js
@@ -2,51 +2,64 @@
 
 const assert = require('assert')
 const LiquidityCurve = require('../src/lib/liquidity-curve')
-const Reader = require('oer-utils').Reader
 
 describe('LiquidityCurve', function () {
   describe('constructor', function () {
     it('saves the points', function () {
       const points = [ [1, 2], [3, 4] ]
       const curve = new LiquidityCurve(points)
-      assert.deepEqual(curve.points, points)
-    })
-  })
-
-  describe('setPoints', function () {
-    it('sets the points', function () {
-      const curve = new LiquidityCurve([])
-      const points = [ [1, 2], [3, 4] ]
-      curve.setPoints(points)
-      assert.deepEqual(curve.points, points)
+      assert.deepEqual(curve.getPoints(), points)
     })
 
+    /* eslint-disable no-unused-vars */
     it('throws InvalidLiquidityCurveError if a point has a negative x-coordinate', function () {
-      const curve = new LiquidityCurve([])
       assert.throws(() => {
-        curve.setPoints([ [-1, 5], [1, 5] ])
-      }, /InvalidLiquidityCurveError: Curve has point with negative x-coordinate/)
+        const curve = new LiquidityCurve([ [-1, 5], [1, 5] ])
+      }, /InvalidLiquidityCurveError: Cannot parse negative value: -1/)
     })
 
     it('throws InvalidLiquidityCurveError if a point has a negative y-coordinate', function () {
-      const curve = new LiquidityCurve([])
       assert.throws(() => {
-        curve.setPoints([ [1, -5], [2, 5] ])
-      }, /InvalidLiquidityCurveError: Curve has point with negative y-coordinate/)
+        const curve = new LiquidityCurve([ [1, -5], [2, 5] ])
+      }, /InvalidLiquidityCurveError: Cannot parse negative value: -5/)
     })
 
     it('throws InvalidLiquidityCurveError if the x-coordinates are not strictly increasing', function () {
-      const curve = new LiquidityCurve([])
       assert.throws(() => {
-        curve.setPoints([ [1, 1], [3, 3], [3, 5] ])
+        const curve = new LiquidityCurve([ [1, 1], [3, 3], [3, 5] ])
       }, /InvalidLiquidityCurveError: Curve x-coordinates must strictly increase in series/)
     })
 
     it('throws InvalidLiquidityCurveError if the y-coordinates are not increasing', function () {
-      const curve = new LiquidityCurve([])
       assert.throws(() => {
-        curve.setPoints([ [1, 1], [3, 3], [5, 2] ])
+        const curve = new LiquidityCurve([ [1, 1], [3, 3], [5, 2] ])
       }, /InvalidLiquidityCurveError: Curve y-coordinates must increase in series/)
+    })
+
+    it('throws an error if the buffer is an invalid length', function () {
+      assert.throws(() => {
+        const curve = new LiquidityCurve(Buffer.from([0]))
+      }, /Invalid LiquidityCurve buffer/)
+    })
+    /* eslint-enable no-unused-vars */
+
+    it('deserializes an empty buffer to an empty curve', function () {
+      const curve = new LiquidityCurve(Buffer.from([]))
+      assert.deepEqual(curve.getPoints(), [])
+    })
+
+    it('deserializes a curve buffer', function () {
+      const points = [ [0, 0], [10, 20] ]
+      const originalCurve = new LiquidityCurve(points)
+      const curve = new LiquidityCurve(originalCurve.toBuffer())
+      assert.deepEqual(curve.getPoints(), points)
+    })
+
+    it('deserializes a base64-encoded string', function () {
+      const points = [ [0, 0], [10, 20] ]
+      const originalCurve = new LiquidityCurve(points)
+      const curve = new LiquidityCurve(originalCurve.toBuffer().toString('base64'))
+      assert.deepEqual(curve.getPoints(), points)
     })
   })
 
@@ -63,7 +76,7 @@ describe('LiquidityCurve', function () {
 
     it('returns 0 if "x" is too low', function () {
       assert.equal(curve.amountAt(0), 0)
-      assert.equal(curve.amountAt(-10), 0)
+      assert.equal(curve.amountAt(5), 0)
     })
 
     it('returns the maximum if "x" is too high', function () {
@@ -89,12 +102,12 @@ describe('LiquidityCurve', function () {
 
     it('returns the minimum "x" if "y" is too low', function () {
       assert.equal(curve.amountReverse(0), 10)
-      assert.equal(curve.amountReverse(-10), 10)
+      assert.equal(curve.amountReverse(10), 10)
     })
 
     it('returns Infinity if "y" is too high', function () {
-      assert.equal(curve.amountReverse(201), Infinity)
-      assert.equal(curve.amountReverse(1000), Infinity)
+      assert.equal(curve.amountReverse(201).toNumber(), Infinity)
+      assert.equal(curve.amountReverse(1000).toNumber(), Infinity)
     })
 
     it('returns the linear interpolation of intermediate "y" values', function () {
@@ -106,91 +119,6 @@ describe('LiquidityCurve', function () {
   })
 
   describe('combine', function () {
-    it('doesnt create non-increasing y coordinates', function () {
-      // these values are from logs of the alpha-network, where non-increasing y coordinates were happening:
-      const curve1 = new LiquidityCurve([
-        [ 3.1106513517718273e-9, 0 ],
-        [ 3.1823209022210673e-9, 6.554011045591627e-11 ],
-        [ 3.8945426576388946e-8, 3.2770055227955495e-8 ],
-        [ 910129733768357, 833960056822929.9 ],
-        [ 100000000000000000, 91630898967551630 ]
-      ])
-      const curve2 = new LiquidityCurve([
-       [ 1.098235347143601e-9, 0 ],
-       [ 908309474300820.4, 833960056822929.8 ]
-      ])
-      assert.deepEqual(curve1.combine(curve2).points, [
-        [ 1.098235347143601e-9, 0 ],
-        [ 3.1106513517718273e-9, 1.8476902565207704e-9 ],
-        [ 3.1823209022210673e-9, 1.9134933160023747e-9 ],
-        [ 3.8945426576388946e-8, 3.47492199973205e-8 ],
-        [ 908309474300820.4, 833960056822929.8 ],
-        [ 910129733768356.9, 833960056822929.8 ],
-        [ 910129733768357, 833960056822929.9 ],
-        [ 100000000000000000, 91630898967551630 ]
-      ])
-
-      const curve3 = new LiquidityCurve([
-        [0.00020060160400962244, 0],
-        [0.00040200802808986955, 0.00020060160400962241],
-        [0.000503014056202274, 0.0003012040120336898],
-        [0.0007056337687421677, 0.000503014056202274],
-        [0.0007496108045235741, 0.0005468153597486979],
-        [0.0007924267074637062, 0.0005894601703406812],
-        [0.0008072482652727131, 0.0006042225012046833],
-        [0.0009090663980688507, 0.0007056337687421676],
-        [0.000996207552844874, 0.000792426707463706],
-        [0.0010110885752192891, 0.000807248265272713],
-        [0.00111331520563055, 0.0009090663980688504],
-        [0.001215746699028607, 0.001011088575219289],
-        [0.001318383465960528, 0.0011133152056305498],
-        [0.0013183834659605282, 0.0011133152056305498],
-        [0.0013183834659605284, 0.00111331520563055],
-        [0.0014262022291075132, 0.0012207031249999996],
-        [0.00244140625, 0.002231850390625],
-        [0.0026518028542054043, 0.002441406249999999],
-        [0.0027573174891837716, 0.002546499248496993],
-        [1000000000000, 996003999999.9998]
-      ])
-      const curve4 = new LiquidityCurve([
-        [0.00020060160400962244, 0],
-        [0.00040200802808986955, 0.00020060160400962241],
-        [0.000648111582914527, 0.0004457217290292006],
-        [0.0008072482652727131, 0.0006042225012046833],
-        [0.0009090663980688507, 0.0007056337687421677],
-        [0.000996207552844874, 0.0007924267074637062],
-        [0.0010110885752192891, 0.000807248265272713],
-        [0.001140318692563842, 0.000935961979068357],
-        [0.001215746699028607, 0.001011088575219289],
-        [0.001318383465960528, 0.0011133152056305498]
-      ])
-      assert.deepEqual(curve3.combine(curve4).points, [
-        [0.00020060160400962244, 0],
-        [0.00040200802808986955, 0.00020060160400962241],
-        [0.000503014056202274, 0.0003012040120336898],
-        [0.000648111582914527, 0.00044572172902920067],
-        [0.0007056337687421677, 0.000503014056202274],
-        [0.0007496108045235741, 0.0005468153597486979],
-        [0.0007924267074637062, 0.0005894601703406812],
-        [0.0008072482652727131, 0.0006042225012046833],
-        [0.0009090663980688507, 0.0007056337687421677],
-        [0.000996207552844874, 0.0007924267074637062],
-        [0.0010110885752192891, 0.000807248265272713],
-        [0.001065340909090909, 0.0008612838068181818],
-        [0.00111331520563055, 0.0009090663980688505],
-        [0.001140318692563842, 0.000935961979068357],
-        [0.001215746699028607, 0.001011088575219289],
-        [0.001318383465960528, 0.0011133152056305498],
-        [0.0013183834659605282, 0.0011133152056305498],
-        [0.0013183834659605284, 0.0011133152056305498],
-        [0.0013183834659605286, 0.0011133152056305498],
-        [0.0014262022291075132, 0.0012207031249999996],
-        [0.00244140625, 0.002231850390625],
-        [0.0026518028542054043, 0.002441406249999999],
-        [0.0027573174891837716, 0.002546499248496993],
-        [1000000000000, 996003999999.9998]
-      ])
-    })
     it('finds an intersection between a slope and a flat line', function () {
       const curve1 = new LiquidityCurve([ [0, 0], [50, 60] ])
       const curve2 = new LiquidityCurve([ [0, 0], [100, 100] ])
@@ -213,8 +141,14 @@ describe('LiquidityCurve', function () {
 
     it('finds an intersection between two slopes', function () {
       const curve1 = new LiquidityCurve([ [0, 0], [100, 1000] ])
-      const curve2 = new LiquidityCurve([ [0, 0], [100 / 3, 450], [200 / 3, 550] ])
-      const result = [ [0, 0], [100 / 3, 450], [50, 500], [200 / 3, 666.6666666666667], [100, 1000] ]
+      const curve2 = new LiquidityCurve([ [0, 0], [33, 450], [66, 550] ])
+      const result = [
+        [0, 0],
+        [33, 450],
+        [50, 502],
+        [66, 660],
+        [100, 1000]
+      ]
       assert.deepEqual(curve1.combine(curve2).getPoints(), result)
       assert.deepEqual(curve2.combine(curve1).getPoints(), result)
     })
@@ -226,7 +160,7 @@ describe('LiquidityCurve', function () {
       const curve2 = new LiquidityCurve([ [0, 0], [50, 60] ])
       const joinedCurve = curve1.join(curve2)
 
-      assert.deepStrictEqual(joinedCurve.points,
+      assert.deepStrictEqual(joinedCurve.getPoints(),
         [ [0, 0], [100, 60] ])
       assert.equal(joinedCurve.amountAt(50), 30)
       assert.equal(joinedCurve.amountAt(100), 60)
@@ -237,7 +171,7 @@ describe('LiquidityCurve', function () {
       const curve1 = new LiquidityCurve([ [0, 0], [50, 100] ])
       const curve2 = new LiquidityCurve([ [0, 0], [200, 300] ])
       const joinedCurve = curve1.join(curve2)
-      assert.deepEqual(joinedCurve.points,
+      assert.deepEqual(joinedCurve.getPoints(),
         [ [0, 0], [50, 150] ])
     })
 
@@ -245,7 +179,7 @@ describe('LiquidityCurve', function () {
       const curve1 = new LiquidityCurve([ [0, 0], [10, 10] ])
       const curve2 = new LiquidityCurve([ [1, 1], [11, 11] ])
       const joinedCurve = curve1.join(curve2)
-      assert.deepEqual(joinedCurve.points,
+      assert.deepEqual(joinedCurve.getPoints(),
         [ [1, 1], [10, 10] ])
     })
   })
@@ -253,19 +187,19 @@ describe('LiquidityCurve', function () {
   describe('shiftX', function () {
     it('shifts all of the points\' Xs by the specified amount', function () {
       const curve = new LiquidityCurve([ [0, 0], [50, 60], [100, 100] ])
-      assert.deepStrictEqual(curve.shiftX(1).points,
+      assert.deepStrictEqual(curve.shiftX(1).getPoints(),
         [ [1, 0], [51, 60], [101, 100] ])
     })
 
     it('stays positive', function () {
       const curve = new LiquidityCurve([ [0, 0], [10, 10] ])
-      assert.deepStrictEqual(curve.shiftX(-5).points,
+      assert.deepStrictEqual(curve.shiftX(-5).getPoints(),
         [ [0, 5], [5, 10] ])
     })
 
     it('shifts a single point and stays positive', function () {
       const curve = new LiquidityCurve([ [5, 5] ])
-      assert.deepStrictEqual(curve.shiftX(-10).points,
+      assert.deepStrictEqual(curve.shiftX(-10).getPoints(),
         [ [0, 5] ])
     })
   })
@@ -273,13 +207,13 @@ describe('LiquidityCurve', function () {
   describe('shiftY', function () {
     it('shifts all of the points\' Ys by the specified amount', function () {
       const curve = new LiquidityCurve([ [0, 0], [50, 60], [100, 100] ])
-      assert.deepStrictEqual(curve.shiftY(1).points,
+      assert.deepStrictEqual(curve.shiftY(1).getPoints(),
         [ [0, 1], [50, 61], [100, 101] ])
     })
 
     it('stays positive', function () {
       const curve = new LiquidityCurve([ [0, 0], [10, 10] ])
-      assert.deepStrictEqual(curve.shiftY(-5).points,
+      assert.deepStrictEqual(curve.shiftY(-5).getPoints(),
         [ [5, 0], [10, 5] ])
     })
   })
@@ -293,31 +227,11 @@ describe('LiquidityCurve', function () {
     it('serializes a curve', function () {
       const curve = new LiquidityCurve([ [0, 0], [10, 20] ])
       const buffer = curve.toBuffer()
-      const reader = Reader.from(buffer)
       assert.equal(buffer.length, 32)
-      assert.deepEqual(reader.readUInt64(), [0, 0]) // points[0][0]
-      assert.deepEqual(reader.readUInt64(), [0, 0]) // points[0][1]
-      assert.deepEqual(reader.readUInt64(), [0, 10]) // points[1][0]
-      assert.deepEqual(reader.readUInt64(), [0, 20]) // points[1][1]
-    })
-  })
-
-  describe('fromBuffer', function () {
-    it('deserializes an empty buffer to an empty curve', function () {
-      const curve = LiquidityCurve.fromBuffer(Buffer.from([]))
-      assert.deepEqual(curve.points, [])
-    })
-
-    it('deserializes a curve', function () {
-      const originalCurve = new LiquidityCurve([ [0, 0], [10, 20] ])
-      const curve = LiquidityCurve.fromBuffer(originalCurve.toBuffer())
-      assert.deepEqual(curve.points, [ [0, 0], [10, 20] ])
-    })
-
-    it('throws an error if the buffer is an invalid length', function () {
-      assert.throws(() => {
-        LiquidityCurve.fromBuffer(Buffer.from([0]))
-      }, /Invalid LiquidityCurve buffer/)
+      assert.deepEqual(buffer.readUInt32LE(4), 0) // points[0][0]
+      assert.deepEqual(buffer.readUInt32LE(12), 0) // points[0][1]
+      assert.deepEqual(buffer.readUInt32LE(20), 10) // points[1][0]
+      assert.deepEqual(buffer.readUInt32LE(28), 20) // points[1][1]
     })
   })
 })

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -57,10 +57,6 @@ describe('Route', function () {
       it('finds the corresponding amount', function () {
         assert.equal(route.amountAt(55), 110)
       })
-
-      it('returns 0 if the actual value is negative', function () {
-        assert.equal(route.shiftY(-40).amountAt(10), 0)
-      })
     })
 
     describe('amountReverse', function () {
@@ -185,7 +181,7 @@ describe('Route', function () {
       }, [['some.path.']])
       const route2 = route1.shiftX(1)
       assert.equal(route2.isLocal, true)
-      assert.deepEqual(route2.curve.points,
+      assert.deepEqual(route2.curve.getPoints(),
         [[1, 0], [51, 60], [101, 100]])
       assert.deepEqual(route2.paths, [['some.path.']])
     })
@@ -200,7 +196,7 @@ describe('Route', function () {
       }, [['some.path.']])
       const route2 = route1.shiftY(1)
       assert.equal(route2.isLocal, true)
-      assert.deepEqual(route2.curve.points,
+      assert.deepEqual(route2.curve.getPoints(),
         [[0, 1], [50, 61], [100, 101]])
       assert.deepEqual(route2.paths, [['some.path.']])
     })

--- a/test/routing-table.test.js
+++ b/test/routing-table.test.js
@@ -2,10 +2,9 @@
 
 const assert = require('assert')
 const RoutingTable = require('../src/lib/routing-table')
-// Cheat to make the tests easier...
-// RoutingTable only requires amountAt and amountReverse.
-const Curve = require('../src/lib/liquidity-curve')
+const Route = require('../src/lib/route')
 
+const ledgerA = 'ledgerA.'
 const ledgerB = 'ledgerB.'
 const markB = ledgerB + 'mark'
 const maryB = ledgerB + 'mary'
@@ -14,7 +13,7 @@ describe('RoutingTable', function () {
   describe('addRoute', function () {
     it('stores a route', function () {
       const table = new RoutingTable()
-      const route = new Curve([])
+      const route = new Route([], [ledgerA, ledgerB], {})
       table.addRoute(ledgerB, markB, route)
       assert.equal(table.destinations.get(ledgerB).get(markB), route)
     })
@@ -23,7 +22,7 @@ describe('RoutingTable', function () {
   describe('removeRoute', function () {
     it('removes a route', function () {
       const table = new RoutingTable()
-      table.addRoute(ledgerB, markB, new Curve([]))
+      table.addRoute(ledgerB, markB, new Route([], [ledgerA, ledgerB], {}))
       table.removeRoute(ledgerB, markB)
       assert.equal(table.destinations.size(), 0)
     })
@@ -37,16 +36,16 @@ describe('RoutingTable', function () {
   describe('findBestHopForSourceAmount', function () {
     it('returns the best hop', function () {
       const table = new RoutingTable()
-      const routeMark = new Curve([[0, 0], [100, 100]])
-      const routeMary = new Curve([[0, 0], [50, 60]])
+      const routeMark = new Route([[0, 0], [100, 100]], [ledgerA, ledgerB], {})
+      const routeMary = new Route([[0, 0], [50, 60]], [ledgerA, ledgerB], {})
       table.addRoute(ledgerB, markB, routeMark)
       table.addRoute(ledgerB, maryB, routeMary)
       assert.deepEqual(table.findBestHopForSourceAmount(ledgerB, 50),
-        { bestHop: maryB, bestValue: 60, bestRoute: routeMary })
+        { bestHop: maryB, bestValue: '60', bestRoute: routeMary })
       assert.deepEqual(table.findBestHopForSourceAmount(ledgerB, 70),
-        { bestHop: markB, bestValue: 70, bestRoute: routeMark })
+        { bestHop: markB, bestValue: '70', bestRoute: routeMark })
       assert.deepEqual(table.findBestHopForSourceAmount(ledgerB, 200),
-        { bestHop: markB, bestValue: 100, bestRoute: routeMark })
+        { bestHop: markB, bestValue: '100', bestRoute: routeMark })
     })
 
     it('returns undefined when there is no route to the destination', function () {
@@ -58,14 +57,14 @@ describe('RoutingTable', function () {
   describe('findBestHopForDestinationAmount', function () {
     it('returns the best hop', function () {
       const table = new RoutingTable()
-      const routeMark = new Curve([[0, 0], [100, 100]])
-      const routeMary = new Curve([[0, 0], [50, 60]])
+      const routeMark = new Route([[0, 0], [100, 100]], [ledgerA, ledgerB], {})
+      const routeMary = new Route([[0, 0], [50, 60]], [ledgerA, ledgerB], {})
       table.addRoute(ledgerB, markB, routeMark)
       table.addRoute(ledgerB, maryB, routeMary)
       assert.deepEqual(table.findBestHopForDestinationAmount(ledgerB, 60),
-        { bestHop: maryB, bestCost: 50, bestRoute: routeMary })
+        { bestHop: maryB, bestCost: '50', bestRoute: routeMary })
       assert.deepEqual(table.findBestHopForDestinationAmount(ledgerB, 70),
-        { bestHop: markB, bestCost: 70, bestRoute: routeMark })
+        { bestHop: markB, bestCost: '70', bestRoute: routeMark })
     })
 
     it('returns undefined when there is no route to the destination', function () {
@@ -75,7 +74,7 @@ describe('RoutingTable', function () {
 
     it('returns undefined when no route has a high enough destination amount', function () {
       const table = new RoutingTable()
-      table.addRoute(ledgerB, markB, new Curve([[0, 0], [100, 100]]))
+      table.addRoute(ledgerB, markB, new Route([[0, 0], [100, 100]], [ledgerA, ledgerB], {}))
       assert.strictEqual(table.findBestHopForDestinationAmount(ledgerB, 200), undefined)
     })
   })

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const RoutingTables = require('../src/lib/routing-tables')
+const LiquidityCurve = require('../src/lib/liquidity-curve')
 const sinon = require('sinon')
 
 const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
@@ -170,10 +171,10 @@ describe('RoutingTables', function () {
       ])
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerB, 100),
-        { bestHop: markB, bestValue: 50 })
+        { bestHop: markB, bestValue: '50' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerB, 200),
-        { bestHop: markB, bestValue: 100 })
+        { bestHop: markB, bestValue: '100' })
     })
   })
 
@@ -181,19 +182,19 @@ describe('RoutingTables', function () {
     it('finds the best next hop when there is one route', function () {
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerB, 0),
-        { bestHop: markB, bestValue: 0 })
+        { bestHop: markB, bestValue: '0' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerB, 100),
-        { bestHop: markB, bestValue: 50 })
+        { bestHop: markB, bestValue: '50' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerB, 200),
-        { bestHop: markB, bestValue: 100 })
+        { bestHop: markB, bestValue: '100' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerB, 300),
-        { bestHop: markB, bestValue: 100 })
+        { bestHop: markB, bestValue: '100' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerB, ledgerA, 100),
-        { bestHop: markA, bestValue: 200 })
+        { bestHop: markA, bestValue: '200' })
     })
 
     it('finds the best next hop when there are multiple hops', function () {
@@ -206,7 +207,7 @@ describe('RoutingTables', function () {
       })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 100),
-        { bestHop: ledgerB + 'mary', bestValue: 25 })
+        { bestHop: ledgerB + 'mary', bestValue: '25' })
     })
 
     it('finds the best next hop when there are multiple routes', function () {
@@ -226,13 +227,13 @@ describe('RoutingTables', function () {
       })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 100),
-        { bestHop: ledgerB + 'mary', bestValue: 60 })
+        { bestHop: ledgerB + 'mary', bestValue: '60' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 150),
-        { bestHop: ledgerB + 'martin', bestValue: 75 })
+        { bestHop: ledgerB + 'martin', bestValue: '75' })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 200),
-        { bestHop: ledgerB + 'martin', bestValue: 100 })
+        { bestHop: ledgerB + 'martin', bestValue: '100' })
     })
   })
 
@@ -240,19 +241,19 @@ describe('RoutingTables', function () {
     it('finds the best next hop when there is one route', function () {
       assertSubset(
         this.tables._findBestHopForDestinationAmount(ledgerA, ledgerB, 0),
-        { bestHop: markB, bestCost: 0 })
+        { bestHop: markB, bestCost: '0' })
       assertSubset(
         this.tables._findBestHopForDestinationAmount(ledgerA, ledgerB, 50),
-        { bestHop: markB, bestCost: 100 })
+        { bestHop: markB, bestCost: '100' })
       assertSubset(
         this.tables._findBestHopForDestinationAmount(ledgerA, ledgerB, 100),
-        { bestHop: markB, bestCost: 200 })
+        { bestHop: markB, bestCost: '200' })
       assert.equal(
         this.tables._findBestHopForDestinationAmount(ledgerA, ledgerB, 150),
         undefined)
       assertSubset(
         this.tables._findBestHopForDestinationAmount(ledgerB, ledgerA, 200),
-        { bestHop: markA, bestCost: 100 })
+        { bestHop: markA, bestCost: '100' })
     })
   })
 
@@ -334,7 +335,7 @@ describe('RoutingTables', function () {
       })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 100),
-        { bestHop: ledgerB + 'mary', bestValue: 60 })
+        { bestHop: ledgerB + 'mary', bestValue: '60' })
       this.tables.invalidateConnector(ledgerB + 'mary')
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 100),
@@ -369,11 +370,11 @@ describe('RoutingTables', function () {
       })
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 100),
-        { bestHop: ledgerB + 'mary', bestValue: 60 })
+        { bestHop: ledgerB + 'mary', bestValue: '60' })
       this.tables.invalidateConnectorsRoutesTo(ledgerB + 'mary', ledgerD)
       assertSubset(
         this.tables._findBestHopForSourceAmount(ledgerA, ledgerC, 100),
-        { bestHop: ledgerB + 'mary', bestValue: 60 })
+        { bestHop: ledgerB + 'mary', bestValue: '60' })
     })
   })
 
@@ -450,7 +451,7 @@ describe('RoutingTables', function () {
           destination_ledger: ledgerA,
           min_message_window: 1,
           source_account: markB,
-          points: [ [0, 0], [100, 200] ],
+          points: serializePoints([ [0, 0], [100, 200] ]),
           added_during_epoch: 0,
           paths: [ [] ]
         }, {
@@ -458,12 +459,12 @@ describe('RoutingTables', function () {
           destination_ledger: ledgerC,
           min_message_window: 3,
           source_account: markA,
-          points: [
+          points: serializePoints([
             [0, 0], /* .. mary .. */
             [100, 60], /* .. mary (max) .. */
             [120, 60], /* .. mark .. */
             [200, 100] /* .. mark (max) */
-          ],
+          ]),
           added_during_epoch: 2,
           paths: [ [] ]
         }, {
@@ -471,7 +472,7 @@ describe('RoutingTables', function () {
           destination_ledger: ledgerB,
           min_message_window: 1,
           source_account: markA,
-          points: [ [0, 0], [200, 100] ],
+          points: serializePoints([ [0, 0], [200, 100] ]),
           added_during_epoch: 0,
           paths: [ [] ]
         }
@@ -480,7 +481,7 @@ describe('RoutingTables', function () {
 
     ;[
       {
-        desc: 'finds an intersection between a segment a tail',
+        desc: 'finds an intersection between a segment and a tail',
         mary: [ [0, 0], [100, 1000] ],
         martin: [ [0, 0], [10, 500] ],
         output: [
@@ -493,12 +494,12 @@ describe('RoutingTables', function () {
       {
         desc: 'finds an intersection between two segments with slope > 0',
         mary: [ [0, 0], [100, 1000] ],
-        martin: [ [0, 0], [100 / 3, 450], [200 / 3, 550] ],
+        martin: [ [0, 0], [20, 450], [80, 550] ],
         output: [
           [0, 0], /* .. martin (segment 1) .. */
-          [200 / 3, 450], /* .. martin (segment 2) .. */
+          [40, 450], /* .. martin (segment 2) .. */
           [100, 500], /* .. mary .. */
-          [400 / 3, 666.6666666666667], /* .. mary (redundant point) .. */
+          [160, 800], /* .. mary (redundant point) .. */
           [200, 1000] /* .. mary .. (max) */
         ]
       }
@@ -519,15 +520,18 @@ describe('RoutingTables', function () {
           points: test.martin
         })
 
-        assert.deepStrictEqual(this.tables.toJSON(10)[1], {
+        const jsonRoute = this.tables.toJSON(10)[1]
+        assert.deepStrictEqual(jsonRoute, {
           source_ledger: ledgerA,
           destination_ledger: ledgerC,
           min_message_window: 2,
           source_account: markA,
-          points: test.output,
+          points: jsonRoute.points,
           added_during_epoch: 2,
           paths: [ [] ]
         })
+        const pointBuffer = Buffer.from(jsonRoute.points, 'base64')
+        assert.deepStrictEqual(new LiquidityCurve(pointBuffer).getPoints(), test.output)
       })
     }, this)
 
@@ -565,8 +569,7 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + 'mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2,
-          liquidityCurve: [ [0, 0], [200, 50] ]
+          minMessageWindow: 2
         })
     })
 
@@ -584,8 +587,7 @@ describe('RoutingTables', function () {
           finalLedger: ledgerB,
           finalAmount: '50',
           minMessageWindow: 1,
-          additionalInfo: {rate_info: '0.5'},
-          liquidityCurve: [ [0, 0], [200, 100] ]
+          additionalInfo: {rate_info: '0.5'}
         })
     })
 
@@ -609,8 +611,7 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + 'mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2,
-          liquidityCurve: [ [0, 0], [200, 50] ]
+          minMessageWindow: 2
         })
     })
   })
@@ -630,9 +631,12 @@ describe('RoutingTables', function () {
           finalLedger: ledgerB,
           finalAmount: '50',
           minMessageWindow: 1,
-          additionalInfo: {rate_info: '0.5'},
-          liquidityCurve: [ [0, 0], [200, 100] ]
+          additionalInfo: {rate_info: '0.5'}
         })
+    })
+
+    it('always returns a string integer destinationAmount', function () {
+      assert.equal(this.tables.findBestHopForSourceAmount(ledgerA, ledgerB, '25').destinationAmount, '12')
     })
   })
 })
@@ -642,4 +646,8 @@ function assertSubset (actual, expect) {
   for (const key in expect) {
     assert.deepStrictEqual(actual[key], expect[key])
   }
+}
+
+function serializePoints (points) {
+  return new LiquidityCurve(points).toBuffer().toString('base64')
 }


### PR DESCRIPTION
* Use BigNumber for internal math. Use integers for points.
* Serialize route points as base64-encoded String instead of an Array of Number.
* Don't include the `liquidityCurve` on `RoutingTables#findBestHopFor{Source,Destination}Amount()`
* add `LiquidityCurve.{toBuffer,fromBuffer}`