### PR TITLE
fix: favor self when rounding during combine()

### DIFF
--- a/src/lib/liquidity-curve.js
+++ b/src/lib/liquidity-curve.js
@@ -258,7 +258,8 @@ class LiquidityCurve {
 
 function omitInfinity (point) { return point[0].toString() !== 'Infinity' }
 function comparePoints (a, b) { return a[0].comparedTo(b[0]) }
-function roundCoords (point) { return [ point[0].floor(), point[1].floor() ] }
+// Round to ensure the connector doesn't lose money.
+function roundCoords (point) { return [ point[0].ceil(), point[1].floor() ] }
 
 function omitDuplicates (point, i, points) {
   return i === 0 || !point[0].eq(points[i - 1][0])

--- a/test/liquidity-curve.test.js
+++ b/test/liquidity-curve.test.js
@@ -133,12 +133,14 @@ describe('LiquidityCurve', function () {
     })
 
     it('cleans up duplicate points', function () {
-      const curve1 = new LiquidityCurve([ [1, 0], [50000000001, 49800199999], [100000000000001, 49800199999] ])
-      const curve2 = new LiquidityCurve([ [2, 0], [50000000001, 49800199999], [100000000000001, 49800199999] ])
+      const curve1 = new LiquidityCurve([ [0, 0], [2, 2] ])
+      const curve2 = new LiquidityCurve([ [1, 0], [2, 9] ])
       const combinedCurve = curve1.combine(curve2)
 
+      // Before rounding, the curve is:
+      // [ [0,0], [1,1], [1.125,1.125], [2,9] ]
       assert.deepStrictEqual(combinedCurve.getPoints(),
-        [ [1, 0], [2, 0], [50000000001, 49800199999], [100000000000001, 49800199999] ])
+        [ [0, 0], [1, 1], [2, 9] ])
     })
 
     it('ignores an empty curve', function () {


### PR DESCRIPTION
`roundCoords` was incorrect because it could round y-values up, which favors the wrong connector.

In addition, intersecting line segments using determinants instead of slopes & y-intercepts results in fewer division operations, yielding a more accurate result.