### PR TITLE
fix: don't invalidate static routes

### DIFF
--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -151,6 +151,9 @@ class RoutingTables {
     let lostLedgerLinks = []
     this.eachSource((table, sourceLedger) => {
       table.destinations.each((_routes, destination) => {
+        const routeToRemove = _routes.get(connectorAccount)
+        // Don't invalidate static routes.
+        if (!routeToRemove || routeToRemove.expiresAt === null) return
         if (table.removeRoute(destination, connectorAccount)) {
           lostLedgerLinks.push(destination)
         }
@@ -163,6 +166,9 @@ class RoutingTables {
     debug('invalidateConnectorsRoutesTo connectorAccount:', connectorAccount, ' ledger:', ledger)
     let lostLedgerLinks = []
     this.eachSource((table, sourceLedger) => {
+      const routeToRemove = this._getRoute(sourceLedger, ledger, connectorAccount)
+      // Don't invalidate static routes.
+      if (!routeToRemove || routeToRemove.expiresAt === null) return
       if (table.removeRoute(ledger, connectorAccount)) {
         lostLedgerLinks.push(ledger)
       }

--- a/test/routing-tables.test.js
+++ b/test/routing-tables.test.js
@@ -358,6 +358,17 @@ describe('RoutingTables', function () {
       let lll = this.tables.invalidateConnector(ledgerB + 'martin')
       assert.deepStrictEqual(lll, [ledgerC])
     })
+
+    it('ignores static routes', function () {
+      this.tables.addRoute({
+        source_ledger: ledgerB,
+        destination_ledger: ledgerC,
+        source_account: ledgerB + 'mary',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }, true)
+      assert.deepEqual(this.tables.invalidateConnector(ledgerB + 'mary'), [])
+    })
   })
 
   describe('invalidateConnectorsRoutesTo', function () {
@@ -390,6 +401,17 @@ describe('RoutingTables', function () {
       assertSubset(
         this.tables.findBestHopForSourceAmount(ledgerA, ledgerC, 100),
         { bestHop: ledgerB + 'mary', bestValue: '60' })
+    })
+
+    it('ignores static routes', function () {
+      this.tables.addRoute({
+        source_ledger: ledgerB,
+        destination_ledger: ledgerC,
+        source_account: ledgerB + 'mary',
+        min_message_window: 1,
+        points: [ [0, 0], [50, 60] ]
+      }, true)
+      assert.deepEqual(this.tables.invalidateConnectorsRoutesTo(ledgerB + 'mary', ledgerC), [])
     })
   })
 


### PR DESCRIPTION
If static routes are invalidated, they can't get added back.