### PR TITLE
feat: prioritize short paths during findBestHop

### DIFF
--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -66,7 +66,7 @@ class Route {
     // are not included in this.paths, so for instance a path:
     // * localLedger -> trustLine -> destinationLedger has this.paths === [ [] ], and path length 2
     // * localLedger -> trustLine -> anotherTrustLine -> destinationLedger has this.paths === [ ['anotherTrustLine'] ] and path length 3
-    return max + 2
+    return this.nextLedger === this.destinationLedger ? max + 2 : max + 3
   }
 
   /**

--- a/test/routing-table.test.js
+++ b/test/routing-table.test.js
@@ -6,6 +6,7 @@ const Route = require('../src/lib/route')
 
 const ledgerA = 'ledgerA.'
 const ledgerB = 'ledgerB.'
+const ledgerC = 'ledgerB.'
 const markB = ledgerB + 'mark'
 const maryB = ledgerB + 'mary'
 
@@ -75,6 +76,16 @@ describe('RoutingTable', function () {
     it('returns undefined when there is no route to the destination', function () {
       const table = new RoutingTable()
       assert.strictEqual(table.findBestHopForSourceAmount(ledgerB, 10), undefined)
+    })
+
+    it('prefers short routes', function () {
+      const table = new RoutingTable()
+      const routeMark = new Route([[0, 0], [100, 999]], {sourceLedger: ledgerA, nextLedger: ledgerB, destinationLedger: ledgerB})
+      const routeMary = new Route([[0, 0], [100, 100]], {sourceLedger: ledgerA, nextLedger: ledgerC, destinationLedger: ledgerB})
+      table.addRoute(ledgerB, markB, routeMark)
+      table.addRoute(ledgerB, ledgerC + 'mary', routeMary)
+      assert.deepEqual(table.findBestHopForSourceAmount(ledgerB, 50),
+        { bestHop: markB, bestValue: '499', bestRoute: routeMark })
     })
   })
 

--- a/test/routing-table.test.js
+++ b/test/routing-table.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const BigNumber = require('bignumber.js')
 const RoutingTable = require('../src/lib/routing-table')
 const Route = require('../src/lib/route')
 
@@ -111,6 +112,55 @@ describe('RoutingTable', function () {
       const table = new RoutingTable()
       table.addRoute(ledgerB, markB, new Route([[0, 0], [100, 100]], [ledgerA, ledgerB], {}))
       assert.strictEqual(table.findBestHopForDestinationAmount(ledgerB, 200), undefined)
+    })
+  })
+
+  describe('getBetterPath', function () {
+    const getBetterPath = RoutingTable._getBetterPath
+
+    it('returns otherPath if there is no currentPath', function () {
+      const otherPath = {}
+      assert.strictEqual(getBetterPath(null, otherPath), otherPath)
+    })
+
+    it('returns the shorter hop', function () {
+      const path1 = {pathLength: 1, value: new BigNumber(1)}
+      const path2 = {pathLength: 2, value: new BigNumber(2)}
+      assert.strictEqual(getBetterPath(path1, path2), path1)
+      assert.strictEqual(getBetterPath(path2, path1), path1)
+    })
+
+    it('returns the hop with the better value', function () {
+      const path1 = {pathLength: 1, value: new BigNumber(1)}
+      const path2 = {pathLength: 1, value: new BigNumber(2)}
+      assert.strictEqual(getBetterPath(path1, path2), path2)
+      assert.strictEqual(getBetterPath(path2, path1), path2)
+    })
+
+    it('returns otherPath when otherPath has a value and currentPath doesn\'t', function () {
+      const path1 = {pathLength: 1}
+      const path2 = {pathLength: 1, value: new BigNumber(1)}
+      assert.strictEqual(getBetterPath(path1, path2), path2)
+    })
+
+    it('returns the hop with the better cost', function () {
+      const path1 = {pathLength: 1, cost: new BigNumber(1)}
+      const path2 = {pathLength: 1, cost: new BigNumber(2)}
+      assert.strictEqual(getBetterPath(path1, path2), path1)
+      assert.strictEqual(getBetterPath(path2, path1), path1)
+    })
+
+    it('returns otherPath when otherPath has a cost and currentPath doesn\'t', function () {
+      const path1 = {pathLength: 1}
+      const path2 = {pathLength: 1, cost: new BigNumber(1)}
+      assert.strictEqual(getBetterPath(path1, path2), path2)
+    })
+
+    it('returns currentPath if neither hop has a curve', function () {
+      const path1 = {pathLength: 1}
+      const path2 = {pathLength: 1}
+      assert.strictEqual(getBetterPath(path1, path2), path1)
+      assert.strictEqual(getBetterPath(path2, path1), path2)
     })
   })
 })


### PR DESCRIPTION
* `findBestHopFor{Source,Destination}Amount()` should prioritize routes based on shortest `maxPathLength()`.
* Fix `maxPathLength()`: if `nextLedger` is not equal to `destinationLedger`, increment the path length.
* Possible fix for https://github.com/interledgerjs/ilp-connector/issues/382. When two paths score the same, return the first in the Map.